### PR TITLE
Convert panic to error in Unseal

### DIFF
--- a/ertcrypto/ertcrypto_test.go
+++ b/ertcrypto/ertcrypto_test.go
@@ -46,6 +46,33 @@ func TestSealAndUnseal(t *testing.T) {
 	assert.EqualValues(testString, plaintext)
 }
 
+func TestCorruptedUnseal(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	testString := "Edgeless"
+
+	// Check what happens if the given ciphertext is nil
+	_, err := Unseal(nil)
+	assert.Error(err)
+
+	// Check what happens if the given ciphertext is too short
+	_, err = Unseal([]byte{0, 1, 2})
+	assert.Error(err)
+
+	// Check what happens if we go out of bounds
+	ciphertext, err := SealWithUniqueKey([]byte(testString))
+	require.NoError(err)
+
+	// Flip two size bits and watch the length go boom :)
+	ciphertext[0] = 0xff
+	ciphertext[1] = 0xff
+
+	// But hopefully, we catched that!
+	_, err = Unseal(ciphertext)
+	assert.Error(err)
+}
+
 func TestInternalSeal(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/ertcrypto/ertcrypto_test.go
+++ b/ertcrypto/ertcrypto_test.go
@@ -52,15 +52,23 @@ func TestCorruptedUnseal(t *testing.T) {
 
 	testString := "Edgeless"
 
-	// Check what happens if the given ciphertext is nil
+	// Check for error if the given ciphertext is nil
 	_, err := Unseal(nil)
 	assert.Error(err)
 
-	// Check what happens if the given ciphertext is too short
+	// Check for error if the given ciphertext is too short
 	_, err = Unseal([]byte{0, 1, 2})
 	assert.Error(err)
 
-	// Check what happens if we go out of bounds
+	// Check for error if the embedded length is 0
+	_, err = Unseal([]byte{0, 0, 0, 0})
+	assert.Error(err)
+
+	// Check for error if the embedded ciphertext is invalid (and specifically, if nonce slicing is not out of bounds)
+	_, err = Unseal([]byte{4, 0, 0, 0, 'i', 'n', 'f', 'o'})
+	assert.Error(err)
+
+	// Check for error if we go out of bounds with an invalid key info length
 	ciphertext, err := SealWithUniqueKey([]byte(testString))
 	require.NoError(err)
 


### PR DESCRIPTION
Simple PR: Convert panics in Unseal to a normal error and return it.

Background: When trying to implement ertcrypto in Marblerun, the "corrupted sealed key" test panicked since it corrupted the length encoding at the beginning of the data, causing an out of bounds error (which panics by default).