### PR TITLE
AB#447 : GetClientTLSConfig() & GetServerTLSConfig() for Marbles

### DIFF
--- a/marble/marble.go
+++ b/marble/marble.go
@@ -1,0 +1,68 @@
+// Package marble provides commonly used functionalities for Marblerun Marbles.
+package marble
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"log"
+	"os"
+)
+
+// GetServerTLSConfig provides a preconfigured server TLS config for the communication between marbles.
+func GetServerTLSConfig() (*tls.Config, error) {
+	tlsCert, roots, err := generateFromEnv()
+	if err != nil {
+		return nil, err
+	}
+
+	tlsConfig := &tls.Config{
+		ClientCAs:    roots,
+		Certificates: []tls.Certificate{tlsCert},
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+	}
+
+	return tlsConfig, nil
+}
+
+// GetClientTLSConfig provides a preconfigured client TLS config for the communication between marbles.
+func GetClientTLSConfig() (*tls.Config, error) {
+	tlsCert, roots, err := generateFromEnv()
+
+	if err != nil {
+		return nil, err
+	}
+
+	tlsConfig := &tls.Config{
+		RootCAs:      roots,
+		Certificates: []tls.Certificate{tlsCert},
+	}
+
+	return tlsConfig, nil
+}
+
+func mustGetEnv(name string) string {
+	value := os.Getenv(name)
+	if len(value) == 0 {
+		log.Fatalln("environment variable not set:", name)
+	}
+	return value
+}
+
+func generateFromEnv() (tls.Certificate, *x509.CertPool, error) {
+	cert := []byte(mustGetEnv("MARBLE_PREDEFINED_MARBLE_CERT"))
+	rootCA := []byte(mustGetEnv("MARBLE_PREDEFINED_ROOT_CA"))
+	privk := []byte(mustGetEnv("MARBLE_PREDEFINED_PRIVATE_KEY"))
+
+	roots := x509.NewCertPool()
+	if !roots.AppendCertsFromPEM(rootCA) {
+		return tls.Certificate{}, nil, fmt.Errorf("cannot append rootCa to CertPool")
+	}
+
+	tlsCert, err := tls.X509KeyPair(cert, privk)
+	if err != nil {
+		return tls.Certificate{}, nil, fmt.Errorf("cannot create TLS cert: %v", err)
+	}
+
+	return tlsCert, roots, nil
+}

--- a/marble/marble.go
+++ b/marble/marble.go
@@ -8,6 +8,15 @@ import (
 	"os"
 )
 
+// MarbleEnvironmentCertificate contains the name of the environment variable holding a marble-specifc PEM encoded certificate
+const MarbleEnvironmentCertificate = "MARBLE_PREDEFINED_MARBLE_CERTIFICATE"
+
+// MarbleEnvironmentRootCA contains the name of the environment variable holding a PEM encoded root certificate
+const MarbleEnvironmentRootCA = "MARBLE_PREDEFINED_ROOT_CA"
+
+// MarbleEnvironmentPrivateKey contains the name of the environment variable holding a PEM encoded private key belonging to the marble-specific certificate
+const MarbleEnvironmentPrivateKey = "MARBLE_PREDEFINED_PRIVATE_KEY"
+
 // GetServerTLSConfig provides a preconfigured server TLS config for the communication between marbles.
 func GetServerTLSConfig() (*tls.Config, error) {
 	tlsCert, roots, err := generateFromEnv()
@@ -39,7 +48,7 @@ func GetClientTLSConfig() (*tls.Config, error) {
 	return tlsConfig, nil
 }
 
-func mustGetByteEnv(name string) ([]byte, error) {
+func getByteEnv(name string) ([]byte, error) {
 	value := os.Getenv(name)
 	if len(value) == 0 {
 		return nil, fmt.Errorf("environment variable not set: %s", name)
@@ -48,15 +57,15 @@ func mustGetByteEnv(name string) ([]byte, error) {
 }
 
 func generateFromEnv() (tls.Certificate, *x509.CertPool, error) {
-	cert, err := mustGetByteEnv("MARBLE_PREDEFINED_MARBLE_CERT")
+	cert, err := getByteEnv(MarbleEnvironmentCertificate)
 	if err != nil {
 		return tls.Certificate{}, nil, err
 	}
-	rootCA, err := mustGetByteEnv("MARBLE_PREDEFINED_ROOT_CA")
+	rootCA, err := getByteEnv(MarbleEnvironmentRootCA)
 	if err != nil {
 		return tls.Certificate{}, nil, err
 	}
-	privk, err := mustGetByteEnv("MARBLE_PREDEFINED_PRIVATE_KEY")
+	privk, err := getByteEnv(MarbleEnvironmentPrivateKey)
 	if err != nil {
 		return tls.Certificate{}, nil, err
 	}

--- a/marble/marble.go
+++ b/marble/marble.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"log"
 	"os"
 )
 
@@ -28,7 +27,6 @@ func GetServerTLSConfig() (*tls.Config, error) {
 // GetClientTLSConfig provides a preconfigured client TLS config for the communication between marbles.
 func GetClientTLSConfig() (*tls.Config, error) {
 	tlsCert, roots, err := generateFromEnv()
-
 	if err != nil {
 		return nil, err
 	}
@@ -41,18 +39,27 @@ func GetClientTLSConfig() (*tls.Config, error) {
 	return tlsConfig, nil
 }
 
-func mustGetEnv(name string) string {
+func mustGetByteEnv(name string) ([]byte, error) {
 	value := os.Getenv(name)
 	if len(value) == 0 {
-		log.Fatalln("environment variable not set:", name)
+		return nil, fmt.Errorf("environment variable not set: %s", name)
 	}
-	return value
+	return []byte(value), nil
 }
 
 func generateFromEnv() (tls.Certificate, *x509.CertPool, error) {
-	cert := []byte(mustGetEnv("MARBLE_PREDEFINED_MARBLE_CERT"))
-	rootCA := []byte(mustGetEnv("MARBLE_PREDEFINED_ROOT_CA"))
-	privk := []byte(mustGetEnv("MARBLE_PREDEFINED_PRIVATE_KEY"))
+	cert, err := mustGetByteEnv("MARBLE_PREDEFINED_MARBLE_CERT")
+	if err != nil {
+		return tls.Certificate{}, nil, err
+	}
+	rootCA, err := mustGetByteEnv("MARBLE_PREDEFINED_ROOT_CA")
+	if err != nil {
+		return tls.Certificate{}, nil, err
+	}
+	privk, err := mustGetByteEnv("MARBLE_PREDEFINED_PRIVATE_KEY")
+	if err != nil {
+		return tls.Certificate{}, nil, err
+	}
 
 	roots := x509.NewCertPool()
 	if !roots.AppendCertsFromPEM(rootCA) {

--- a/marble/marble_test.go
+++ b/marble/marble_test.go
@@ -1,0 +1,183 @@
+package marble
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetServerTLSConfig(t *testing.T) {
+	defer resetEnv()
+	assert := assert.New(t)
+	require := require.New(t)
+
+	// Get server TLS config
+	setupTest(require)
+	tlsConfig, err := GetServerTLSConfig()
+	require.NoError(err)
+	assert.NotNil(tlsConfig)
+
+	// Check client CA certificate
+	clientCAPool := tlsConfig.ClientCAs
+	clientCAPoolSubjects := clientCAPool.Subjects()
+
+	// x509 cert pools don't allow to extract certificates inside them. How great is that? So we gotta extract the ASN.1 subject and work with it.
+	// This was taken (and slightly modified) from: https://github.com/golang/go/issues/26614#issuecomment-613640345
+	var rdnSequence pkix.RDNSequence
+	_, err = asn1.Unmarshal(clientCAPoolSubjects[0], &rdnSequence)
+	require.NoError(err)
+	var name pkix.Name
+	name.FillFromRDNSequence(&rdnSequence)
+	commonName := name.CommonName
+
+	assert.Equal("Test CA", commonName)
+
+	// Check leaf certificate
+	certificates := tlsConfig.Certificates
+	rawCertificate := certificates[0].Certificate[0]
+	x509Cert, err := x509.ParseCertificate(rawCertificate)
+	require.NoError(err)
+	assert.Equal(big.NewInt(1337), x509Cert.SerialNumber)
+	assert.Equal("Test Leaf", x509Cert.Subject.CommonName)
+
+	// Check ClientAuth value
+	assert.Equal(tls.RequireAndVerifyClientCert, tlsConfig.ClientAuth)
+}
+
+func TestGetClientTLSConfig(t *testing.T) {
+	defer resetEnv()
+	assert := assert.New(t)
+	require := require.New(t)
+
+	// Get client TLS config
+	setupTest(require)
+	tlsConfig, err := GetClientTLSConfig()
+	require.NoError(err)
+	assert.NotNil(tlsConfig)
+
+	// Check root certificate
+	rootCertPool := tlsConfig.RootCAs
+	rootCertPoolSubjects := rootCertPool.Subjects()
+
+	// x509 cert pools don't allow to extract certificates inside them. How great is that? So we gotta extract the ASN.1 subject and work with it.
+	// This was taken (and slightly modified) from: https://github.com/golang/go/issues/26614#issuecomment-613640345
+	var rdnSequence pkix.RDNSequence
+	_, err = asn1.Unmarshal(rootCertPoolSubjects[0], &rdnSequence)
+	require.NoError(err)
+	var name pkix.Name
+	name.FillFromRDNSequence(&rdnSequence)
+	commonName := name.CommonName
+
+	assert.Equal("Test CA", commonName)
+
+	// Check leaf certificate
+	certificates := tlsConfig.Certificates
+	rawCertificate := certificates[0].Certificate[0]
+	x509Cert, err := x509.ParseCertificate(rawCertificate)
+	require.NoError(err)
+	assert.Equal(big.NewInt(1337), x509Cert.SerialNumber)
+	assert.Equal("Test Leaf", x509Cert.Subject.CommonName)
+}
+
+func TestGarbageEnviromentVars(t *testing.T) {
+	defer resetEnv()
+	assert := assert.New(t)
+
+	// Set environment variables
+	os.Setenv("MARBLE_PREDEFINED_ROOT_CA", "this")
+	os.Setenv("MARBLE_PREDEFINED_MARBLE_CERT", "is")
+	os.Setenv("MARBLE_PREDEFINED_PRIVATE_KEY", "some serious garbage")
+
+	// This should fail
+	tlsConfig, err := GetServerTLSConfig()
+	assert.Error(err)
+	assert.Nil(tlsConfig)
+}
+
+func TestMissingEnvironmentVars(t *testing.T) {
+	assert := assert.New(t)
+	tlsConfig, err := GetClientTLSConfig()
+
+	assert.Error(err)
+	assert.Nil(tlsConfig)
+}
+
+func setupTest(require *require.Assertions) {
+	// Generate keys
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(err)
+	privKey, err := x509.MarshalPKCS8PrivateKey(key)
+	require.NoError(err)
+
+	// Create some demo CA certificate
+	templateCa := x509.Certificate{
+		SerialNumber: big.NewInt(42),
+		IsCA:         true,
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(time.Hour * 24 * 365),
+		Subject: pkix.Name{
+			CommonName: "Test CA",
+		},
+	}
+
+	// Create some demo leaf certificate
+	templateLeaf := x509.Certificate{
+		SerialNumber: big.NewInt(1337),
+		IsCA:         false,
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(time.Hour * 24 * 365),
+		Subject: pkix.Name{
+			CommonName: "Test Leaf",
+		},
+	}
+
+	// Create test CA cert
+	certCaRaw, err := x509.CreateCertificate(rand.Reader, &templateCa, &templateCa, &key.PublicKey, key)
+	if err != nil {
+		panic(err)
+	}
+
+	certCa, err := x509.ParseCertificate(certCaRaw)
+	if err != nil {
+		panic(err)
+	}
+
+	// Create test leaf cert
+	certLeafRaw, err := x509.CreateCertificate(rand.Reader, &templateLeaf, certCa, &key.PublicKey, key)
+	if err != nil {
+		panic(err)
+	}
+
+	certLeaf, err := x509.ParseCertificate(certLeafRaw)
+	if err != nil {
+		panic(err)
+	}
+
+	// Convert them to PEM
+	caCertPem := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certCa.Raw})
+	leafCertPem := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certLeaf.Raw})
+	privKeyPem := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privKey})
+
+	// Set environment variables
+	os.Setenv("MARBLE_PREDEFINED_ROOT_CA", string(caCertPem))
+	os.Setenv("MARBLE_PREDEFINED_MARBLE_CERT", string(leafCertPem))
+	os.Setenv("MARBLE_PREDEFINED_PRIVATE_KEY", string(privKeyPem))
+}
+
+func resetEnv() {
+	// Clean up used environment variables, otherwise they stay set!
+	os.Unsetenv("MARBLE_PREDEFINED_ROOT_CA")
+	os.Unsetenv("MARBLE_PREDEFINED_MARBLE_CERT")
+	os.Unsetenv("MARBLE_PREDEFINED_PRIVATE_KEY")
+}


### PR DESCRIPTION
Introduces three new predefined environment variables for Marblerun:

- MARBLE_CERT -> MARBLE_PREDEFINED_MARBLE_CERT
- ROOT_CA -> MARBLE_PREDEFINED_ROOT_CA
- MARBLE_KEY -> MARBLE_PREDEFINED_PRIVATE_KEY 