### PR TITLE
AB#495: Rename environment variables for intermediate CA & certificate chain

### DIFF
--- a/marble/marble.go
+++ b/marble/marble.go
@@ -8,11 +8,11 @@ import (
 	"os"
 )
 
-// MarbleEnvironmentCertificate contains the name of the environment variable holding a marble-specifc PEM encoded certificate
-const MarbleEnvironmentCertificate = "MARBLE_PREDEFINED_MARBLE_CERTIFICATE"
+// MarbleEnvironmentCertificateChain contains the name of the environment variable holding a marble-specifc PEM encoded certificate
+const MarbleEnvironmentCertificateChain = "MARBLE_PREDEFINED_MARBLE_CERTIFICATE_CHAIN"
 
-// MarbleEnvironmentRootCA contains the name of the environment variable holding a PEM encoded root certificate
-const MarbleEnvironmentRootCA = "MARBLE_PREDEFINED_ROOT_CA"
+// MarbleEnvironmentIntermediateCA contains the name of the environment variable holding a PEM encoded root certificate
+const MarbleEnvironmentIntermediateCA = "MARBLE_PREDEFINED_INTERMEDIATE_CA"
 
 // MarbleEnvironmentPrivateKey contains the name of the environment variable holding a PEM encoded private key belonging to the marble-specific certificate
 const MarbleEnvironmentPrivateKey = "MARBLE_PREDEFINED_PRIVATE_KEY"
@@ -46,25 +46,25 @@ func getByteEnv(name string) ([]byte, error) {
 }
 
 func generateFromEnv() (tls.Certificate, *x509.CertPool, error) {
-	cert, err := getByteEnv(MarbleEnvironmentCertificate)
+	certChain, err := getByteEnv(MarbleEnvironmentCertificateChain)
 	if err != nil {
 		return tls.Certificate{}, nil, err
 	}
-	rootCA, err := getByteEnv(MarbleEnvironmentRootCA)
+	intermediateCA, err := getByteEnv(MarbleEnvironmentIntermediateCA)
 	if err != nil {
 		return tls.Certificate{}, nil, err
 	}
-	privk, err := getByteEnv(MarbleEnvironmentPrivateKey)
+	leafPrivk, err := getByteEnv(MarbleEnvironmentPrivateKey)
 	if err != nil {
 		return tls.Certificate{}, nil, err
 	}
 
 	roots := x509.NewCertPool()
-	if !roots.AppendCertsFromPEM(rootCA) {
-		return tls.Certificate{}, nil, fmt.Errorf("cannot append rootCa to CertPool")
+	if !roots.AppendCertsFromPEM(intermediateCA) {
+		return tls.Certificate{}, nil, fmt.Errorf("cannot append intermediateCA as rootCA to CertPool")
 	}
 
-	tlsCert, err := tls.X509KeyPair(cert, privk)
+	tlsCert, err := tls.X509KeyPair(certChain, leafPrivk)
 	if err != nil {
 		return tls.Certificate{}, nil, fmt.Errorf("cannot create TLS cert: %v", err)
 	}

--- a/marble/marble_test.go
+++ b/marble/marble_test.go
@@ -61,8 +61,8 @@ func TestGarbageEnviromentVars(t *testing.T) {
 	assert := assert.New(t)
 
 	// Set environment variables
-	os.Setenv(MarbleEnvironmentRootCA, "this")
-	os.Setenv(MarbleEnvironmentCertificate, "is")
+	os.Setenv(MarbleEnvironmentIntermediateCA, "this")
+	os.Setenv(MarbleEnvironmentCertificateChain, "is")
 	os.Setenv(MarbleEnvironmentPrivateKey, "some serious garbage")
 
 	// This should fail
@@ -128,15 +128,15 @@ func setupTest(require *require.Assertions) {
 	privKeyPem := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privKey})
 
 	// Set environment variables
-	os.Setenv(MarbleEnvironmentRootCA, string(caCertPem))
-	os.Setenv(MarbleEnvironmentCertificate, string(leafCertPem))
+	os.Setenv(MarbleEnvironmentIntermediateCA, string(caCertPem))
+	os.Setenv(MarbleEnvironmentCertificateChain, string(leafCertPem))
 	os.Setenv(MarbleEnvironmentPrivateKey, string(privKeyPem))
 }
 
 func resetEnv() {
 	// Clean up used environment variables, otherwise they stay set!
-	os.Unsetenv(MarbleEnvironmentRootCA)
-	os.Unsetenv(MarbleEnvironmentCertificate)
+	os.Unsetenv(MarbleEnvironmentIntermediateCA)
+	os.Unsetenv(MarbleEnvironmentCertificateChain)
 	os.Unsetenv(MarbleEnvironmentPrivateKey)
 }
 


### PR DESCRIPTION
Just renaming variables so that the changes from https://github.com/edgelesssys/marblerun/pull/90 are more apparent.